### PR TITLE
334 ghost restricted rooms

### DIFF
--- a/src/entity/ghost/state_machine/state_moving.gd
+++ b/src/entity/ghost/state_machine/state_moving.gd
@@ -65,6 +65,11 @@ func find_target_door() -> bool:
 	if doors.is_empty():
 		return false
 	
+	# remove old man room from list of doors
+	for door: Door in doors:
+		if door.linked_room is OldManRoom:
+			doors.remove_at(doors.find(door))
+	
 	# pick random door
 	target_door = RNG.random_from_list(doors)
 	target_room = target_door.linked_door.get_parent()

--- a/src/entity/ghost/state_machine/state_moving.gd
+++ b/src/entity/ghost/state_machine/state_moving.gd
@@ -100,6 +100,18 @@ func _on_target_reached() -> void:
 			_parent.set_target(target_door.global_position)
 			state = DoorStates.AT
 		DoorStates.AT:
+			# if target room is shrine room, teleport to adjancent room
+			# and update 
+			if target_room is ShrineRoom:
+				# temporarily set current room to the shrine room
+				_parent.current_room = target_room
+				# find a target door out of the shrine room
+				find_target_door()
+				# teleport ghost to the shrine room
+				_parent.global_position = target_door.global_position
+				_parent.global_position.y = 1
+				# now the following code will update the room to the far side of the shrine room
+			
 			# transition to next room
 			_parent.current_room = target_room
 			_parent.reparent(_parent.current_room)

--- a/src/map/rooms/old_man_room.gd
+++ b/src/map/rooms/old_man_room.gd
@@ -1,0 +1,2 @@
+class_name OldManRoom
+extends Room

--- a/src/map/rooms/old_man_room.gd.uid
+++ b/src/map/rooms/old_man_room.gd.uid
@@ -1,0 +1,1 @@
+uid://b2neeedprnc1

--- a/src/map/rooms/old_man_room.tscn
+++ b/src/map/rooms/old_man_room.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=21 format=3 uid="uid://cpudmguey5gcy"]
 
-[ext_resource type="Script" uid="uid://bo0tyfrjfebc6" path="res://src/map/room_components/room.gd" id="1_gll72"]
+[ext_resource type="Script" uid="uid://b2neeedprnc1" path="res://src/map/rooms/old_man_room.gd" id="1_vb84m"]
 [ext_resource type="PackedScene" uid="uid://te0dpapcosk4" path="res://src/map/rooms/room_minimap/basic_room_minimap.tscn" id="2_winw3"]
 [ext_resource type="Script" uid="uid://dqhrw6rxew3fa" path="res://src/common/door_location.gd" id="3_vb84m"]
 [ext_resource type="Texture2D" uid="uid://diioxrqi1phl4" path="res://src/ui/minimap/old_man_icon.png" id="4_vb84m"]
@@ -41,7 +41,7 @@ required = false
 metadata/_custom_type_script = "uid://dqhrw6rxew3fa"
 
 [node name="OldManRoom" type="Node3D" groups=["rooms"]]
-script = ExtResource("1_gll72")
+script = ExtResource("1_vb84m")
 room_information = SubResource("Resource_hj2hw")
 
 [node name="Floor" parent="." instance=ExtResource("5_7bu5u")]


### PR DESCRIPTION
- Prevent ghosts from entering old man room
    - ghost checks target doors, if a door leads to old man room it deletes it from the array before randomly selecting a door
- Prevent ghosts from entering shrine room
    - ghosts teleport to another door out of the shrine room